### PR TITLE
feat[cart]: Hotwire the Storefront

### DIFF
--- a/app/assets/stylesheets/line_items.css
+++ b/app/assets/stylesheets/line_items.css
@@ -1,0 +1,12 @@
+@keyframes line-item-highlight {
+  0% {
+    background: #8f8;
+  }
+  100% {
+    background: none;
+  }
+}
+
+.line-item-highlight {
+  animation: line-item-highlight 1s;
+}

--- a/app/channels/products_channel.rb
+++ b/app/channels/products_channel.rb
@@ -1,0 +1,10 @@
+class ProductsChannel < ApplicationCable::Channel
+  def subscribed
+    # stream_from "some_channel"
+    stream_from "products"
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/app/controllers/line_items_controller.rb
+++ b/app/controllers/line_items_controller.rb
@@ -28,7 +28,8 @@ class LineItemsController < ApplicationController
 
     respond_to do |format|
       if @line_item.save
-        format.html { redirect_to cart_url(@line_item.cart) }
+        format.turbo_stream { @current_item = @line_item }
+        format.html { redirect_to store_index_url }
         format.json { render :show, status: :created, location: @line_item }
       else
         format.html { render :new, status: :unprocessable_entity }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -41,6 +41,9 @@ class ProductsController < ApplicationController
       if @product.update(product_params)
         format.html { redirect_to product_url(@product), notice: "Product was successfully updated." }
         format.json { render :show, status: :ok, location: @product }
+
+        @product.broadcast_replace_later_to 'products',
+        partial: 'store/product'
       else
         format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @product.errors, status: :unprocessable_entity }

--- a/app/controllers/store_controller.rb
+++ b/app/controllers/store_controller.rb
@@ -1,4 +1,6 @@
 class StoreController < ApplicationController
+  include CurrentCart
+  before_action :set_cart
   def index
     @products = Product.order(:title)
   end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+import "channels"

--- a/app/javascript/channels/consumer.js
+++ b/app/javascript/channels/consumer.js
@@ -1,0 +1,6 @@
+// Action Cable provides the framework to deal with WebSockets in Rails.
+// You can generate new channels where WebSocket features live using the `bin/rails generate channel` command.
+
+import { createConsumer } from "@rails/actioncable"
+
+export default createConsumer()

--- a/app/javascript/channels/index.js
+++ b/app/javascript/channels/index.js
@@ -1,0 +1,2 @@
+// Import all the channels to be used by Action Cable
+import "channels/products_channel"

--- a/app/javascript/channels/products_channel.js
+++ b/app/javascript/channels/products_channel.js
@@ -1,0 +1,15 @@
+import consumer from "channels/consumer"
+
+consumer.subscriptions.create("ProductsChannel", {
+  connected() {
+    // Called when the subscription is ready for use on the server
+  },
+
+  disconnected() {
+    // Called when the subscription has been terminated by the server
+  },
+
+  received(data) {
+    // Called when there's incoming data on the websocket for this channel
+  }
+});

--- a/app/views/carts/_cart.html.erb
+++ b/app/views/carts/_cart.html.erb
@@ -1,20 +1,8 @@
 <div id="<%= dom_id cart %>">
   <h2 class="font-bold text-lg mb-3">Your Cart</h2>
 
-  <table class= "table-auto">
-    <% cart.line_items.each do |line_item| %>
-      <tr>
-        <td class="text-right"?<%= line_item.quantity %><td>
-        <td>&times;</td>
-        <td class="pr-2">
-          <%= line_item.product.title %>
-        </td>
-        <td class="text-right font-bold">
-          <%= number_to_currency(line_item.total_price) %>
-        </td>
-      </tr>
-    <% end %>
-
+  <table class="table-auto">
+    <%= render cart.line_items %>
     <tfoot>
       <tr>
         <th class="text-right pr-2 pt-2" colspan="3">Total:</th>

--- a/app/views/layouts/_cart.html.erb
+++ b/app/views/layouts/_cart.html.erb
@@ -1,0 +1,7 @@
+<% if cart and not cart.line_items.empty? %>
+  <div id="cart" class="bg-white rounded p-2">
+    <%= render cart %>
+  </div>
+<% else %>
+  <div id="cart"></div>
+  <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,19 +6,21 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
-
+    
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
   <body>
     <header class="bg-green-700">
-      <%= image_tag 'logo.svg', alt: 'The Pragmatic Bookshelp' %>
+      <%= image_tag 'logo.svg', alt: 'The Pragmatic Bookshelf' %>
       <h1><%= @page_title %></h1>
     </header>
 
     <section class="flex">
       <nav class="bg-green-900 p-6">
+        <%= render partial: 'layouts/cart', locals: {cart: @cart } %>
+
         <ul class="text-gray-300 leading-8">
           <li><a href="/">Home</a></li>
           <li><a href="/questions">Questions</a></li>

--- a/app/views/line_items/_line_item.html.erb
+++ b/app/views/line_items/_line_item.html.erb
@@ -1,17 +1,14 @@
-<div id="<%= dom_id line_item %>">
-  <p class="my-5">
-    <strong class="block font-medium mb-1">Product:</strong>
-    <%= line_item.product_id %>
-  </p>
-
-  <p class="my-5">
-    <strong class="block font-medium mb-1">Cart:</strong>
-    <%= line_item.cart_id %>
-  </p>
-
-  <% if action_name != "show" %>
-    <%= link_to "Show this line item", line_item, class: "rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
-    <%= link_to 'Edit this line item', edit_line_item_path(line_item), class: "rounded-lg py-3 ml-2 px-5 bg-gray-100 inline-block font-medium" %>
-    <hr class="mt-6">
-  <% end %>
-</div>
+<% if line_item == @current_item %>
+<tr class="line-item-highlight">
+<% else %>
+<tr>
+<% end %>
+  <td class="text-right"><%= line_item.quantity %></td>
+  <td>&times;</td>
+  <td class="pr-2">
+    <%= line_item.product.title %>
+  </td>  
+  <td class="text-right font-bold">
+    <%= number_to_currency(line_item.total_price) %>
+  </td>
+</tr>

--- a/app/views/line_items/create.turbo_stream.erb
+++ b/app/views/line_items/create.turbo_stream.erb
@@ -1,0 +1,7 @@
+<%= turbo_stream.replace 'notice' do %>
+  <%= render partial: 'store/notice', locals: {notice: @notice } %>
+<% end %>
+
+<%= turbo_stream.replace 'cart' do %>
+  <%= render partial: 'layouts/cart', locals: {cart: @cart } %>
+<% end %>

--- a/app/views/store/_notice.html.erb
+++ b/app/views/store/_notice.html.erb
@@ -1,0 +1,8 @@
+<% if notice.present? %>
+  <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg
+            inline-block" id="notice">
+    <%= notice %>
+  </p>
+<% else %>
+  <div id="notice"></div>
+<% end %>

--- a/app/views/store/_product.html.erb
+++ b/app/views/store/_product.html.erb
@@ -1,0 +1,25 @@
+<%= turbo_frame_tag(dom_id(product)) do %>
+  <li class='flex mb-6'>
+    <%= image_tag(product.image_url,
+      class: 'object-contain w-40 h-48 shadow mr-6') %>
+
+    <div>
+      <h2 class="font-bold text-lg mb-3"><%= product.title %></h2>
+
+      <p>
+        <%= sanitize(product.description) %>
+      </p>
+
+      <div class="mt-3">
+        <%= number_to_currency(product.price) %>
+        
+        <%= button_to 'Add to Cart',
+            line_items_path(product_id: product),
+            form_class: 'inline',
+            class: 'ml-4 rounded-lg py-1 px-2
+                    text-white bg-green-600' %>
+      </div>
+    </div>
+  </li>
+<% end %>
+<!-- END_HIGHLIGHT -->

--- a/app/views/store/index.html.erb
+++ b/app/views/store/index.html.erb
@@ -1,41 +1,16 @@
 <div class="w-full">
-<% if notice.present? %>
-  <p class="py-2 px-3 bg-green-50 mb-5 text-green-500 font-medium rounded-lg
-            inline-block" id="notice">
-    <%= notice %>
-  </p>
-<% end %>
+<%= render 'notice' %>
 
 <h1 class="font-bold text-xl mb-6 pb-2 border-b-2">
   Your Pragmatic Catalog
 </h1>
+<%= turbo_stream_from 'products' %>
 
 <ul>
   <% cache @products do %>
     <% @products.each do |product| %>
       <% cache product do %>
-        <li class='flex mb-6'>
-          <%= image_tag(product.image_url,
-            class: 'object-contain w-40 h-48 shadow mr-6') %>
-      
-          <div>
-            <h2 class="font-bold text-lg mb-3"><%= product.title %></h2>
-
-            <p>
-              <%= sanitize(product.description) %>
-            </p>
-
-            <div class="mt-3">
-              <%= number_to_currency(product.price) %>
-              
-              <%= button_to 'Add to Cart',
-                  line_items_path(product_id: product),
-                  form_class: 'inline',
-                  class: 'ml-4 rounded-lg py-1 px-2
-                          text-white bg-green-600' %>
-            </div>
-          </div>
-        </li>
+        <%= render partial: 'product', object:  product %>
       <% end %>
     <% end %>
   <% end %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,3 +5,5 @@ pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
+pin "@rails/actioncable", to: "actioncable.esm.js"
+pin_all_from "app/javascript/channels", under: "channels"

--- a/test/channels/products_channel_test.rb
+++ b/test/channels/products_channel_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class ProductsChannelTest < ActionCable::Channel::TestCase
+  # test "subscribes" do
+  #   subscribe
+  #   assert subscription.confirmed?
+  # end
+end

--- a/test/controllers/carts_controller_test.rb
+++ b/test/controllers/carts_controller_test.rb
@@ -46,6 +46,6 @@ class CartsControllerTest < ActionDispatch::IntegrationTest
       delete cart_url(@cart)
     end
 
-    assert_redirected_to carts_url
+    assert_redirected_to store_index_url
   end
 end

--- a/test/controllers/line_items_controller_test.rb
+++ b/test/controllers/line_items_controller_test.rb
@@ -49,4 +49,14 @@ class LineItemsControllerTest < ActionDispatch::IntegrationTest
 
     assert_redirected_to line_items_url
   end
+
+  test "should create line_item via turbo-stream" do
+    assert_difference('LineItem.count') do
+      post line_items_url, params: { product_id: products(:ruby).id },
+        as: :turbo_stream
+    end
+
+    assert_response :success
+    assert_match /<tr class="line-item-highlight">/, @response.body
+  end
 end


### PR DESCRIPTION
Moves the shopping cart into the sidebar and arranges for the create action to redisplay the catalog page Uses turbo_stream to indicate to the LineItemsController.create() that TurboStreams are supported by the client Uses ERB partial templates to return only the portions of the page that need to be replaced Uses Action Cable and Turbo Frames to update the catalog display whenever a product changes Writes a test that verifies not only the creation of a line item but the content of the response that's returned from such a request

#14: Feature: Hotwiring the Storefront